### PR TITLE
Add version on Delete requests

### DIFF
--- a/ansys/api/acp/v0/model.proto
+++ b/ansys/api/acp/v0/model.proto
@@ -15,6 +15,10 @@ message ModelRequest {
     ResourcePath resource_path = 1;
 }
 
+message DeleteModelRequest {
+    BasicInfo info = 1;
+}
+
 message ModelInfo {
     BasicInfo info = 1;
     message ModelingProperties {
@@ -72,7 +76,7 @@ service Model {
 
     rpc Put(ModelInfo) returns (ModelInfo);
 
-    rpc Delete(ModelRequest) returns (Empty);
+    rpc Delete(DeleteModelRequest) returns (Empty);
 
     rpc Update(UpdateModelRequest) returns (ModelInfo); // TODO: return changed entitites
 

--- a/ansys/api/acp/v0/modeling_group.proto
+++ b/ansys/api/acp/v0/modeling_group.proto
@@ -16,6 +16,10 @@ message PutModelingGroupRequest {
     BasicInfo info = 1;
 }
 
+message DeleteModelingGroupRequest {
+    BasicInfo info = 1;
+}
+
 message ListModelingGroupsRequest {
     CollectionPath collection_path = 1;
 }
@@ -36,7 +40,7 @@ service ModelingGroup {
 
     rpc Put(PutModelingGroupRequest) returns (ModelingGroupReply);
 
-    rpc Delete(ModelingGroupRequest) returns (Empty);
+    rpc Delete(DeleteModelingGroupRequest) returns (Empty);
 
     rpc Create(CreateModelingGroupRequest) returns (ModelingGroupReply);
 }


### PR DESCRIPTION
Use a `BasicInfo` instead of only a `ResourcePath` in the `Delete` endpoints,
such that the version information can also be passed along.

Note that the `name` of the `BasicInfo` is not consumed in the `Delete` method,
so we may decide to use a "slimmed down" request (only resource path + version) 
in the future.