### PR TITLE
Use simplified / harmonized .proto files

### DIFF
--- a/src/ansys/api/acp/v0/base.proto
+++ b/src/ansys/api/acp/v0/base.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
-package ansys.api.acp.v0;
+package ansys.api.acp.v0; // TO DISCUSS: Should we use a '.base' namespace here?
 
-// TODO: use ansys.api.kernel.v0 message types
 message Empty {
 }
 
@@ -18,4 +17,17 @@ message BasicInfo {
     string name = 2;
     string id = 3;
     int64 version = 4;
+}
+
+message GetRequest {
+    ResourcePath resource_path = 1;
+}
+
+message DeleteRequest {
+    ResourcePath resource_path = 1;
+    int64 version = 2;
+}
+
+message ListRequest {
+    CollectionPath collection_path = 1;
 }

--- a/src/ansys/api/acp/v0/element_set.proto
+++ b/src/ansys/api/acp/v0/element_set.proto
@@ -5,11 +5,6 @@ import "ansys/api/acp/v0/base.proto";
 import "ansys/api/acp/v0/array_types.proto";
 import "ansys/api/acp/v0/enum_types.proto";
 
-message ElementSetRequest {
-    ResourcePath resource_path = 1;
-    // TODO: add a 'view' that determines which parts are returned
-}
-
 message ElementSetProperties {
     enum_types.StatusType status = 1;
     bool locked = 2;
@@ -17,43 +12,29 @@ message ElementSetProperties {
     array_types.IntArray element_labels = 4;
 }
 
-message ElementSetReply {
+message ElementSetInfo {
     BasicInfo info = 1;
     ElementSetProperties properties = 2;
-}
-
-message PutElementSetRequest {
-    BasicInfo info = 1;
-    ElementSetProperties properties = 2;
-}
-
-message DeleteElementSetRequest {
-    BasicInfo info = 1;
-}
-
-message ListElementSetsRequest {
-    CollectionPath collection_path = 1;
 }
 
 message ListElementSetsReply {
-    repeated ElementSetReply element_sets = 1;
+    repeated ElementSetInfo objects = 1;
 }
 
 message CreateElementSetRequest {
     CollectionPath collection_path = 1;
     string name = 2;
     ElementSetProperties properties = 3;
-
 }
 
 service ElementSet {
-    rpc List(ListElementSetsRequest) returns (ListElementSetsReply);
+    rpc List(ListRequest) returns (ListElementSetsReply);
 
-    rpc Get(ElementSetRequest) returns (ElementSetReply);
+    rpc Get(GetRequest) returns (ElementSetInfo);
 
-    rpc Put(PutElementSetRequest) returns (ElementSetReply);
+    rpc Put(ElementSetInfo) returns (ElementSetInfo);
 
-    rpc Delete(DeleteElementSetRequest) returns (Empty);
+    rpc Delete(DeleteRequest) returns (Empty);
 
-    rpc Create(CreateElementSetRequest) returns (ElementSetReply);
+    rpc Create(CreateElementSetRequest) returns (ElementSetInfo);
 }

--- a/src/ansys/api/acp/v0/model.proto
+++ b/src/ansys/api/acp/v0/model.proto
@@ -11,14 +11,6 @@ enum Format {
     NASTRAN_BDF = 4;
 }
 
-message ModelRequest {
-    ResourcePath resource_path = 1;
-}
-
-message DeleteModelRequest {
-    BasicInfo info = 1;
-}
-
 message ModelInfo {
     BasicInfo info = 1;
     message ModelingProperties {
@@ -29,7 +21,7 @@ message ModelInfo {
         double relative_thickness_tolerance = 5;
         double minimum_analysis_ply_thickness = 6;
     }
-    ModelingProperties modeling_properties = 2;
+    ModelingProperties properties = 2;
 }
 
 message LoadModelRequest {
@@ -61,24 +53,20 @@ message SaveModelRequest {
     bool save_cache = 3;
 }
 
-message ListModelsRequest {
-    CollectionPath collection_path = 1;
-}
-
 message ListModelsReply {
-    repeated ModelInfo models = 1;
+    repeated ModelInfo objects = 1;
 }
 
 service Model {
-    rpc List(ListModelsRequest) returns (ListModelsReply);
+    rpc List(ListRequest) returns (ListModelsReply);
 
-    rpc Get(ModelRequest) returns (ModelInfo);
+    rpc Get(GetRequest) returns (ModelInfo);
 
     rpc Put(ModelInfo) returns (ModelInfo);
 
-    rpc Delete(DeleteModelRequest) returns (Empty);
+    rpc Delete(DeleteRequest) returns (Empty);
 
-    rpc Update(UpdateModelRequest) returns (ModelInfo); // TODO: return changed entitites
+    rpc Update(UpdateModelRequest) returns (ModelInfo); // TODO: return changed entitites (?)
 
     rpc LoadFromFile(LoadModelRequest) returns (ModelInfo);
 

--- a/src/ansys/api/acp/v0/modeling_group.proto
+++ b/src/ansys/api/acp/v0/modeling_group.proto
@@ -1,46 +1,34 @@
 syntax = "proto3";
-package ansys.api.acp.v0;
+package ansys.api.acp.v0.modeling_group;
 
 import "ansys/api/acp/v0/base.proto";
 
-message ModelingGroupRequest {
-    ResourcePath resource_path = 1;
-    // TODO: add a 'view' that determines which parts are returned
+message ModelingGroupProperties {
 }
 
-message ModelingGroupReply {
+message ModelingGroupInfo {
     BasicInfo info = 1;
-}
-
-message PutModelingGroupRequest {
-    BasicInfo info = 1;
-}
-
-message DeleteModelingGroupRequest {
-    BasicInfo info = 1;
-}
-
-message ListModelingGroupsRequest {
-    CollectionPath collection_path = 1;
+    ModelingGroupProperties properties = 2;
 }
 
 message ListModelingGroupsReply {
-    repeated ModelingGroupReply modeling_groups = 1;
+    repeated ModelingGroupInfo objects = 1;
 }
 
 message CreateModelingGroupRequest {
     CollectionPath collection_path = 1;
     string name = 2;
+    ModelingGroupProperties properties = 3;
 }
 
 service ModelingGroup {
-    rpc List(ListModelingGroupsRequest) returns (ListModelingGroupsReply);
+    rpc List(ListRequest) returns (ListModelingGroupsReply);
 
-    rpc Get(ModelingGroupRequest) returns (ModelingGroupReply);
+    rpc Get(GetRequest) returns (ModelingGroupInfo);
 
-    rpc Put(PutModelingGroupRequest) returns (ModelingGroupReply);
+    rpc Put(ModelingGroupInfo) returns (ModelingGroupInfo);
 
-    rpc Delete(DeleteModelingGroupRequest) returns (Empty);
+    rpc Delete(DeleteRequest) returns (Empty);
 
-    rpc Create(CreateModelingGroupRequest) returns (ModelingGroupReply);
+    rpc Create(CreateModelingGroupRequest) returns (ModelingGroupInfo);
 }

--- a/src/ansys/api/acp/v0/rosette.proto
+++ b/src/ansys/api/acp/v0/rosette.proto
@@ -13,10 +13,6 @@ enum Type {
         EDGE_WISE = 4;
 }
 
-message RosetteRequest {
-    ResourcePath resource_path = 1;
-}
-
 message RosetteProperties {
     enum_types.StatusType status = 1;
     bool locked = 2;
@@ -26,26 +22,13 @@ message RosetteProperties {
     array_types.DoubleArray dir2 = 6;
 }
 
-message RosetteReply {
+message RosetteInfo {
     BasicInfo info = 1;
     RosetteProperties properties = 2;
-}
-
-message PutRosetteRequest {
-    BasicInfo info = 1;
-    RosetteProperties properties = 2;
-}
-
-message DeleteRosetteRequest {
-    BasicInfo info = 1;
-}
-
-message ListRosettesRequest {
-    CollectionPath collection_path = 1;
 }
 
 message ListRosettesReply {
-    repeated RosetteReply rosettes = 1;
+    repeated RosetteInfo objects = 1;
 }
 
 message CreateRosetteRequest {
@@ -55,13 +38,13 @@ message CreateRosetteRequest {
 }
 
 service Rosette {
-    rpc List(ListRosettesRequest) returns (ListRosettesReply);
+    rpc List(ListRequest) returns (ListRosettesReply);
 
-    rpc Get(RosetteRequest) returns (RosetteReply);
+    rpc Get(GetRequest) returns (RosetteInfo);
 
-    rpc Put(PutRosetteRequest) returns (RosetteReply);
+    rpc Put(RosetteInfo) returns (RosetteInfo);
 
-    rpc Delete(DeleteRosetteRequest) returns (Empty);
+    rpc Delete(DeleteRequest) returns (Empty);
 
-    rpc Create(CreateRosetteRequest) returns (RosetteReply);
+    rpc Create(CreateRosetteRequest) returns (RosetteInfo);
 }


### PR DESCRIPTION
Use the simplified and harmonized .proto definitions: Message types are made generic where possible, and message and property names are made consistent across types.