### PR TITLE
add rotation angle to the proto of the Oriented Selection Set

### DIFF
--- a/src/ansys/api/acp/v0/oriented_selection_set.proto
+++ b/src/ansys/api/acp/v0/oriented_selection_set.proto
@@ -25,6 +25,7 @@ message Properties {
     double draping_mesh_size = 13;
     ply_material.DrapingMaterialType draping_material_model = 14;
     double draping_ud_coefficient = 15;
+    double rotation_angle = 16;
 }
 
 message ObjectInfo {


### PR DESCRIPTION
Update proto of Oriented Selection Set because a new parameter rotation angle was added in the backend.