### PR TITLE
Dependabot: group updates, add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,23 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*" # Update all packages together
+    cooldown:
+      include:
+        - '*'
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*" # Update all packages together
+    cooldown:
+      include:
+        - '*'
+      default-days: 7


### PR DESCRIPTION
- Group dependabot updates to minimize the number of maintenance PRs created.
- Add a cooldown of 7 days as a security measure against compromised dependencies.