### PR TITLE
Update protobuf files, requirements, and pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.14'
   PACKAGE_NAME: 'ansys-api-acp'
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.12.1
+  rev: 26.5.1
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.13.2
+  rev: 9.0.0a3
   hooks:
   - id: isort
 - repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
+  rev: 7.3.0
   hooks:
   - id: flake8
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.2.8
+  rev: v0.8.0
   hooks:
   - id: add-license-headers
     args:

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
 MIT License
 
-Copyright (c) 2022 - 2024 ANSYS, Inc. All rights reserved.
+Copyright (c) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,8 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
-<<<<<<< Updated upstream
-        python_requires=">=3.7",
-        install_requires=["grpcio~=1.17", "protobuf>=3.19,<8"],
-=======
         python_requires=">=3.11",
-        install_requires=["grpcio~=1.71", "protobuf>=5.19,<8"],
->>>>>>> Stashed changes
+        install_requires=["grpcio~=1.71", "protobuf>=5.29,<8"],
         package_dir={"": "src"},
         packages=setuptools.find_namespace_packages("src", include=("ansys.*",)),
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,13 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         url=f"https://github.com/ansys/{package_name}",
         license="MIT",
+<<<<<<< Updated upstream
         python_requires=">=3.7",
         install_requires=["grpcio~=1.17", "protobuf>=3.19,<8"],
+=======
+        python_requires=">=3.11",
+        install_requires=["grpcio~=1.71", "protobuf>=5.19,<8"],
+>>>>>>> Stashed changes
         package_dir={"": "src"},
         packages=setuptools.find_namespace_packages("src", include=("ansys.*",)),
         package_data={

--- a/src/ansys/api/acp/__init__.py
+++ b/src/ansys/api/acp/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 #

--- a/src/ansys/api/acp/v0/analysis_ply.proto
+++ b/src/ansys/api/acp/v0/analysis_ply.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/array_types.proto
+++ b/src/ansys/api/acp/v0/array_types.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/base.proto
+++ b/src/ansys/api/acp/v0/base.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/boolean_selection_rule.proto
+++ b/src/ansys/api/acp/v0/boolean_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/butt_joint_sequence.proto
+++ b/src/ansys/api/acp/v0/butt_joint_sequence.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/cad_component.proto
+++ b/src/ansys/api/acp/v0/cad_component.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/cad_geometry.proto
+++ b/src/ansys/api/acp/v0/cad_geometry.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/control.proto
+++ b/src/ansys/api/acp/v0/control.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/cut_off_geometry.proto
+++ b/src/ansys/api/acp/v0/cut_off_geometry.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/cut_off_material.proto
+++ b/src/ansys/api/acp/v0/cut_off_material.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/cutoff_selection_rule.proto
+++ b/src/ansys/api/acp/v0/cutoff_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/cylindrical_selection_rule.proto
+++ b/src/ansys/api/acp/v0/cylindrical_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/drop_off_material.proto
+++ b/src/ansys/api/acp/v0/drop_off_material.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/edge_set.proto
+++ b/src/ansys/api/acp/v0/edge_set.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/element_set.proto
+++ b/src/ansys/api/acp/v0/element_set.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/enum_types.proto
+++ b/src/ansys/api/acp/v0/enum_types.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //
@@ -88,4 +88,5 @@ enum FileFormat {
     STEP = 5;
     IGES = 6;
     STL = 7;
+    LSDYNA_K = 8;
 }

--- a/src/ansys/api/acp/v0/extrusion_guide.proto
+++ b/src/ansys/api/acp/v0/extrusion_guide.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/geometrical_selection_rule.proto
+++ b/src/ansys/api/acp/v0/geometrical_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/hdf5_composite_cae_import.proto
+++ b/src/ansys/api/acp/v0/hdf5_composite_cae_import.proto
@@ -21,34 +21,69 @@
 // SOFTWARE.
 
 syntax = "proto3";
-package ansys.api.acp.v0.fabric;
-option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/fabric";
+package ansys.api.acp.v0.hdf5_composite_cae_import;
+option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/hdf5_composite_cae_import";
 
 import "ansys/api/acp/v0/base.proto";
 import "ansys/api/acp/v0/enum_types.proto";
-import "ansys/api/acp/v0/ply_material.proto";
-import "ansys/api/acp/v0/cut_off_material.proto";
-import "ansys/api/acp/v0/drop_off_material.proto";
+import "ansys/api/acp/v0/import_object.proto";
+
+// Default CRUD messages
+
+enum ImportMode {
+    APPEND = 0;
+    OVERWRITE = 1;
+}
+
+enum ProjectionMode {
+    SHELL = 0;
+    SOLID = 1;
+}
+
+message ShellMappingProperties {
+    // MAPPING SCOPE
+    optional bool all_elements = 1;
+    repeated base.ResourcePath element_sets = 2;
+
+    // TOLERANCES
+    optional double relative_thickness_tolerance = 3;
+    optional double relative_in_plane_tolerance = 4;
+    optional double angle_tolerance = 5;
+    optional double small_hole_threshold = 6;
+}
+
+message SolidMappingProperties {
+    optional enum_types.OffsetType offset_type = 1;
+}
+
+message CoordinateTransformation {
+    // all angles are in degrees
+    double rotation_angle_x = 1;
+    double rotation_angle_y = 2;
+    double rotation_angle_z = 3;
+    double translation_x = 4;
+    double translation_y = 5;
+    double translation_z = 6;
+}
 
 message Properties {
-    enum_types.StatusType status = 1;
-    base.ResourcePath material = 9;
-    double thickness = 2;
-    double area_price = 3;
-    bool ignore_for_postprocessing = 4;
-
-    // SOLID MODEL OPTIONS
-    drop_off_material.MaterialHandlingType drop_off_material_handling = 5;
-    base.ResourcePath drop_off_material = 11;
-    cut_off_material.MaterialHandlingType cut_off_material_handling = 6;
-    base.ResourcePath cut_off_material = 12;
-
-    // DRAPING OPTIONS
-    ply_material.DrapingMaterialType draping_material_model = 7;
-    double draping_ud_coefficient = 8;
-
     // READ-ONLY PROPERTIES
-    double area_weight = 10;
+    bool has_run = 1;
+
+    // GENERAL SETTINGS
+    string path = 2;
+    optional ProjectionMode projection_mode = 3;
+    optional ImportMode import_mode = 4;
+
+    // PLY ANGLES (both modes)
+    optional double minimum_angle_tolerance = 5;
+    optional bool recompute_reference_directions = 6;
+
+    // SHELL MAPPING PROPERTIES
+    ShellMappingProperties shell_mapping_properties = 7;
+
+    // SOLID MAPPING PROPERTIES
+    SolidMappingProperties solid_mapping_properties = 8;
 }
 
 message ObjectInfo {
@@ -74,4 +109,14 @@ service ObjectService {
     rpc Delete(base.DeleteRequest) returns (base.Empty);
 
     rpc Create(CreateRequest) returns (ObjectInfo);
+
+    // Special Import Object RPCs
+
+    rpc Run(import_object.RunRequest) returns (base.Empty);
+
+    rpc ListGeneratedObjects(import_object.ListGeneratedObjectsRequest)
+        returns (import_object.ListGeneratedObjectsReply);
+
+    rpc DeleteGeneratedObjects(import_object.DeleteGeneratedObjectsRequest)
+        returns (base.Empty);
 }

--- a/src/ansys/api/acp/v0/import_object.proto
+++ b/src/ansys/api/acp/v0/import_object.proto
@@ -21,43 +21,17 @@
 // SOFTWARE.
 
 syntax = "proto3";
-package ansys.api.acp.v0.field_definition;
-option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/field_definition";
+package ansys.api.acp.v0.import_object;
+option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/import_object";
 
 import "ansys/api/acp/v0/base.proto";
-import "ansys/api/acp/v0/enum_types.proto";
 
-message Properties {
-    enum_types.StatusType status = 1;
-    bool locked = 2;
-    bool active = 3;
-    string field_variable_name = 4;
-    repeated base.ResourcePath scope_entities = 5;
-    base.ResourcePath scalar_field = 6;
-    bool full_mapping = 7;
+message RunRequest { base.ResourcePath resource_path = 1; }
+
+message ListGeneratedObjectsRequest { base.ResourcePath resource_path = 1; }
+
+message ListGeneratedObjectsReply {
+    repeated base.ResourcePath generated_objects = 1;
 }
 
-message ObjectInfo {
-    base.BasicInfo info = 1;
-    Properties properties = 2;
-}
-
-message ListReply { repeated ObjectInfo objects = 1; }
-
-message CreateRequest {
-    base.CollectionPath collection_path = 1;
-    string name = 2;
-    Properties properties = 3;
-}
-
-service ObjectService {
-    rpc List(base.ListRequest) returns (ListReply);
-
-    rpc Get(base.GetRequest) returns (ObjectInfo);
-
-    rpc Put(ObjectInfo) returns (ObjectInfo);
-
-    rpc Delete(base.DeleteRequest) returns (base.Empty);
-
-    rpc Create(CreateRequest) returns (ObjectInfo);
-}
+message DeleteGeneratedObjectsRequest { base.ResourcePath resource_path = 1; }

--- a/src/ansys/api/acp/v0/imported_analysis_ply.proto
+++ b/src/ansys/api/acp/v0/imported_analysis_ply.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/imported_modeling_group.proto
+++ b/src/ansys/api/acp/v0/imported_modeling_group.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/imported_modeling_ply.proto
+++ b/src/ansys/api/acp/v0/imported_modeling_ply.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/imported_production_ply.proto
+++ b/src/ansys/api/acp/v0/imported_production_ply.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/imported_solid_model.proto
+++ b/src/ansys/api/acp/v0/imported_solid_model.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/interface_layer.proto
+++ b/src/ansys/api/acp/v0/interface_layer.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/layup_mapping_object.proto
+++ b/src/ansys/api/acp/v0/layup_mapping_object.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/linked_selection_rule.proto
+++ b/src/ansys/api/acp/v0/linked_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/lookup_table_1d.proto
+++ b/src/ansys/api/acp/v0/lookup_table_1d.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/lookup_table_1d_column.proto
+++ b/src/ansys/api/acp/v0/lookup_table_1d_column.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/lookup_table_3d.proto
+++ b/src/ansys/api/acp/v0/lookup_table_3d.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/lookup_table_3d_column.proto
+++ b/src/ansys/api/acp/v0/lookup_table_3d_column.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/lookup_table_column_type.proto
+++ b/src/ansys/api/acp/v0/lookup_table_column_type.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/material.proto
+++ b/src/ansys/api/acp/v0/material.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //
@@ -136,7 +136,8 @@ message PuckConstantsPropertySet {
     repeated Data values = 1;
     repeated FieldVariable field_variables = 2;
     InterpolationOptions interpolation_options = 3;
-    string mat_type = 4;
+    string mat_type =
+        4; // Valid values: "carbon", "glass", "material-specific".
 }
 
 message IsotropicThermalExpansionCoefficientsPropertySet {

--- a/src/ansys/api/acp/v0/mesh_query.proto
+++ b/src/ansys/api/acp/v0/mesh_query.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/model.proto
+++ b/src/ansys/api/acp/v0/model.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //
@@ -27,6 +27,7 @@ option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/model";
 import "ansys/api/acp/v0/base.proto";
 import "ansys/api/acp/v0/unit_system.proto";
 import "ansys/api/acp/v0/enum_types.proto";
+import "ansys/api/acp/v0/hdf5_composite_cae_import.proto";
 
 // Default CRUD messages
 
@@ -115,59 +116,28 @@ message ExportHDF5CompositeCAERequest {
         10; // can be Modeling Group or Modeling Ply
 };
 
-enum ImportMode {
-    APPEND = 0;
-    OVERWRITE = 1;
-}
-
-enum ProjectionMode {
-    SHELL = 0;
-    SOLID = 1;
-}
-
-message ShellMappingProperties {
-    // MAPPING SCOPE
-    bool all_elements = 1;
-    repeated base.ResourcePath element_sets = 2;
-
-    // PLY AREA MAPPING
-    double relative_thickness_tolerance = 3;
-    double relative_in_plane_tolerance = 4;
-    double angle_tolerance = 5;
-    double small_hole_threshold = 6;
-}
-
-message SolidMappingProperties { enum_types.OffsetType offset_type = 1; }
-
-message CoordinateTransformation {
-    // all angles are in degrees
-    double rotation_angle_x = 1;
-    double rotation_angle_y = 2;
-    double rotation_angle_z = 3;
-    double translation_x = 4;
-    double translation_y = 5;
-    double translation_z = 6;
-}
-
 message ImportHDF5CompositeCAERequest {
     // GENERAL PROPERTIES
     base.ResourcePath resource_path = 1;
     string path = 2;
-    ImportMode import_mode = 3;
-    ProjectionMode projection_mode = 4;
+    hdf5_composite_cae_import.ImportMode import_mode = 3;
+    hdf5_composite_cae_import.ProjectionMode projection_mode = 4;
 
     // PLY ANGLES
     double minimum_angle_tolerance = 5;
     bool recompute_reference_directions = 6;
 
-    // MAPPIG PROPERTIES
+    // MAPPING PROPERTIES
     oneof mapping_properties {
-        ShellMappingProperties shell_mapping_properties = 7;
-        SolidMappingProperties solid_mapping_properties = 8;
+        hdf5_composite_cae_import.ShellMappingProperties
+            shell_mapping_properties = 7;
+        hdf5_composite_cae_import.SolidMappingProperties
+            solid_mapping_properties = 8;
     }
 
     // COORDINATE TRANSFORMATION
-    CoordinateTransformation coordinate_transformation = 9;
+    hdf5_composite_cae_import.CoordinateTransformation
+        coordinate_transformation = 9;
 }
 
 service ObjectService {
@@ -195,6 +165,7 @@ service ObjectService {
     rpc ExportHDF5CompositeCAE(ExportHDF5CompositeCAERequest)
         returns (base.Empty);
 
+    // Deprecated: use hdf5_composite_cae_import.ObjectService instead
     rpc ImportHDF5CompositeCAE(ImportHDF5CompositeCAERequest)
         returns (base.Empty);
 

--- a/src/ansys/api/acp/v0/modeling_group.proto
+++ b/src/ansys/api/acp/v0/modeling_group.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/modeling_ply.proto
+++ b/src/ansys/api/acp/v0/modeling_ply.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/oriented_selection_set.proto
+++ b/src/ansys/api/acp/v0/oriented_selection_set.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/parallel_selection_rule.proto
+++ b/src/ansys/api/acp/v0/parallel_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/ply_geometry_export.proto
+++ b/src/ansys/api/acp/v0/ply_geometry_export.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/ply_material.proto
+++ b/src/ansys/api/acp/v0/ply_material.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/production_ply.proto
+++ b/src/ansys/api/acp/v0/production_ply.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/rosette.proto
+++ b/src/ansys/api/acp/v0/rosette.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/sampling_point.proto
+++ b/src/ansys/api/acp/v0/sampling_point.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/section_cut.proto
+++ b/src/ansys/api/acp/v0/section_cut.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //
@@ -70,12 +70,13 @@ message Properties {
     IntersectionType intersection_type = 13;
 
     // surface properties - general
-    bool use_default_tolerance = 14;
-    double tolerance = 15;
+    bool use_default_minimum_segment_length = 14;
+    double minimum_segment_length = 15;
     // surface properties - sweep-based
     bool use_default_interpolation_settings = 16;
     double search_radius = 17;
     int64 number_of_interpolation_points = 18;
+    double minimum_thickness_to_length_ratio = 19;
 }
 
 message ObjectInfo {
@@ -106,6 +107,7 @@ message ExportToCDBRequest {
     base.ResourcePath resource_path = 1;
     string path = 2;
     CDBExportType export_type = 3;
+    optional double extrusion_depth = 4;
 }
 
 service ObjectService {

--- a/src/ansys/api/acp/v0/sensor.proto
+++ b/src/ansys/api/acp/v0/sensor.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/snap_to_geometry.proto
+++ b/src/ansys/api/acp/v0/snap_to_geometry.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/solid_element_set.proto
+++ b/src/ansys/api/acp/v0/solid_element_set.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/solid_model.proto
+++ b/src/ansys/api/acp/v0/solid_model.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/solid_model_export.proto
+++ b/src/ansys/api/acp/v0/solid_model_export.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/spherical_selection_rule.proto
+++ b/src/ansys/api/acp/v0/spherical_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/stackup.proto
+++ b/src/ansys/api/acp/v0/stackup.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/sublaminate.proto
+++ b/src/ansys/api/acp/v0/sublaminate.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/tube_selection_rule.proto
+++ b/src/ansys/api/acp/v0/tube_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/unit_system.proto
+++ b/src/ansys/api/acp/v0/unit_system.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //
@@ -34,6 +34,7 @@ enum UnitSystemType {
     MPA = 5;
     BFT = 6;
     BIN = 7;
+    MMKMS = 8;
 }
 
 enum DimensionType {

--- a/src/ansys/api/acp/v0/variable_offset_selection_rule.proto
+++ b/src/ansys/api/acp/v0/variable_offset_selection_rule.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/virtual_geometry.proto
+++ b/src/ansys/api/acp/v0/virtual_geometry.proto
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+// Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 //
 //

--- a/src/ansys/api/acp/v0/winding_wizard.proto
+++ b/src/ansys/api/acp/v0/winding_wizard.proto
@@ -21,34 +21,35 @@
 // SOFTWARE.
 
 syntax = "proto3";
-package ansys.api.acp.v0.fabric;
-option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/fabric";
+package ansys.api.acp.v0.winding_wizard;
+option go_package = "github.com/ansys/ansys-api-acp/ansys/api/acp/v0/winding_wizard";
 
 import "ansys/api/acp/v0/base.proto";
-import "ansys/api/acp/v0/enum_types.proto";
-import "ansys/api/acp/v0/ply_material.proto";
-import "ansys/api/acp/v0/cut_off_material.proto";
-import "ansys/api/acp/v0/drop_off_material.proto";
+import "ansys/api/acp/v0/array_types.proto";
+import "ansys/api/acp/v0/import_object.proto";
+
+// Default CRUD messages
+
+message Layer {
+    base.ResourcePath fabric = 1;
+    optional double nominal_angle = 2;
+    optional bool has_limits = 3;
+    optional double lower_limit = 4;
+    optional double upper_limit = 5;
+    optional bool add_mirrored_ply = 6;
+}
 
 message Properties {
-    enum_types.StatusType status = 1;
-    base.ResourcePath material = 9;
-    double thickness = 2;
-    double area_price = 3;
-    bool ignore_for_postprocessing = 4;
-
-    // SOLID MODEL OPTIONS
-    drop_off_material.MaterialHandlingType drop_off_material_handling = 5;
-    base.ResourcePath drop_off_material = 11;
-    cut_off_material.MaterialHandlingType cut_off_material_handling = 6;
-    base.ResourcePath cut_off_material = 12;
-
-    // DRAPING OPTIONS
-    ply_material.DrapingMaterialType draping_material_model = 7;
-    double draping_ud_coefficient = 8;
-
     // READ-ONLY PROPERTIES
-    double area_weight = 10;
+    bool has_run = 1;
+
+    // READ-WRITE PROPERTIES
+    array_types.DoubleArray origin = 2;
+    optional double reference_radius = 3;
+    array_types.DoubleArray axial_direction = 4;
+    optional double max_angle_with_thickness_correction = 5;
+    optional int32 number_of_digits_angle = 6;
+    repeated Layer layers = 7;
 }
 
 message ObjectInfo {
@@ -74,4 +75,14 @@ service ObjectService {
     rpc Delete(base.DeleteRequest) returns (base.Empty);
 
     rpc Create(CreateRequest) returns (ObjectInfo);
+
+    // Special Import Object RPCs
+
+    rpc Run(import_object.RunRequest) returns (base.Empty);
+
+    rpc ListGeneratedObjects(import_object.ListGeneratedObjectsRequest)
+        returns (import_object.ListGeneratedObjectsReply);
+
+    rpc DeleteGeneratedObjects(import_object.DeleteGeneratedObjectsRequest)
+        returns (base.Empty);
 }


### PR DESCRIPTION
- Update changes to the protobuf files from the backend.
- Drop support for Python 3.7 - 3.10, add 3.14
- Bump minimum required versions to `grpcio>=1.71`, `protobuf>=5.29` to match `ansys-tools-protoc-helper==0.7.0`.
- Update and run pre-commit hooks, in particular to update the license header.
- Update the license file.